### PR TITLE
LCA: cleanup + test fixture formatting

### DIFF
--- a/lca/BUILD.bazel
+++ b/lca/BUILD.bazel
@@ -1,0 +1,19 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################
+
+cc_library(
+    name = "lca",
+    srcs = [
+        "src/lca.cpp",
+        "src/tree_node.cpp",
+    ],
+    hdrs = glob(["include/*.hpp"], allow_empty = True),
+    includes = [
+        "include",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/lca/README.md
+++ b/lca/README.md
@@ -1,0 +1,3 @@
+# Least Common Ancestor
+
+LeetCode: [Lowest Common Ancestor of a Binary Tree](https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree/)

--- a/lca/include/lca.hpp
+++ b/lca/include/lca.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+struct TreeNode;
+
+auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q) -> TreeNode*;

--- a/lca/include/tree_node.hpp
+++ b/lca/include/tree_node.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+struct TreeNode
+{
+    int val;
+    TreeNode* left;
+    TreeNode* right;
+
+    TreeNode();
+    explicit TreeNode(int x);
+    TreeNode(int x, TreeNode* left, TreeNode* right);
+};

--- a/lca/src/lca.cpp
+++ b/lca/src/lca.cpp
@@ -3,7 +3,8 @@
 
 #include <cstdint>
 
-enum class State : std::uint8_t {
+enum class State : std::uint8_t
+{
     None = 0,
     P = 1u << 0,
     Q = 1u << 1,
@@ -34,45 +35,58 @@ constexpr auto operator&=(State& lhs, State rhs) noexcept -> State&
 
 auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q, State& state) -> TreeNode*
 {
-    if (root == p) {
+    if (root == p)
+    {
         state |= State::P;
     }
-    if (root == q) {
+    if (root == q)
+    {
         state |= State::Q;
     }
-    if (state == State::Both) {
+    if (state == State::Both)
+    {
         return root;
     }
-    if (state == State::None) {
-        if (root->left) {
+    if (state == State::None)
+    {
+        if (root->left)
+        {
             auto node = lowest_common_ancestor(root->left, p, q, state);
-            if (state == State::Both) {
+            if (state == State::Both)
+            {
                 return node;
             }
         }
-        if (!root->right) {
+        if (!root->right)
+        {
             return nullptr;
         }
-        if (state == State::None) {
+        if (state == State::None)
+        {
             return lowest_common_ancestor(root->right, p, q, state);
         }
         lowest_common_ancestor(root->right, p, q, state);
-        if (state == State::Both) {
+        if (state == State::Both)
+        {
             return root;
         }
         return nullptr;
     }
-    if (root->left) {
+    if (root->left)
+    {
         lowest_common_ancestor(root->left, p, q, state);
     }
-    if (state == State::Both) {
+    if (state == State::Both)
+    {
         return root;
     }
-    if (!root->right) {
+    if (!root->right)
+    {
         return nullptr;
     }
     lowest_common_ancestor(root->right, p, q, state);
-    if (state == State::Both) {
+    if (state == State::Both)
+    {
         return root;
     }
     return nullptr;
@@ -80,7 +94,8 @@ auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q, State& sta
 
 auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q) -> TreeNode*
 {
-    if (!root || !p || !q) {
+    if (!root || !p || !q)
+    {
         return nullptr;
     }
     State state = State::None;

--- a/lca/src/lca.cpp
+++ b/lca/src/lca.cpp
@@ -1,0 +1,93 @@
+#include "lca.hpp"
+#include "tree_node.hpp"
+
+#include <cstdint>
+
+enum class State : std::uint8_t {
+    None = 0,
+    P = 1u << 0,
+    Q = 1u << 1,
+    Both = P | Q,
+};
+
+constexpr auto operator|(State lhs, State rhs) noexcept -> State
+{
+    return static_cast<State>(static_cast<std::uint8_t>(lhs) | static_cast<std::uint8_t>(rhs));
+}
+
+constexpr auto operator&(State lhs, State rhs) noexcept -> State
+{
+    return static_cast<State>(static_cast<std::uint8_t>(lhs) & static_cast<std::uint8_t>(rhs));
+}
+
+constexpr auto operator|=(State& lhs, State rhs) noexcept -> State&
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr auto operator&=(State& lhs, State rhs) noexcept -> State&
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr auto has_flag(State value, State flag) noexcept -> bool
+{
+    return (value & flag) == flag;
+}
+
+auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q, State& state) -> TreeNode*
+{
+    if (root == p) {
+        state |= State::P;
+    }
+    if (root == q) {
+        state |= State::Q;
+    }
+    if (state == State::Both) {
+        return root;
+    }
+    if (state == State::None) {
+        if (root->left) {
+            auto node = lowest_common_ancestor(root->left, p, q, state);
+            if (state == State::Both) {
+                return node;
+            }
+        }
+        if (!root->right) {
+            return nullptr;
+        }
+        if (state == State::None) {
+            return lowest_common_ancestor(root->right, p, q, state);
+        }
+        lowest_common_ancestor(root->right, p, q, state);
+        if (state == State::Both) {
+            return root;
+        }
+        return nullptr;
+    }
+    if (root->left) {
+        lowest_common_ancestor(root->left, p, q, state);
+    }
+    if (state == State::Both) {
+        return root;
+    }
+    if (!root->right) {
+        return nullptr;
+    }
+    lowest_common_ancestor(root->right, p, q, state);
+    if (state == State::Both) {
+        return root;
+    }
+    return nullptr;
+}
+
+auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q) -> TreeNode*
+{
+    if (!root || !p || !q) {
+        return nullptr;
+    }
+    State state = State::None;
+    return lowest_common_ancestor(root, p, q, state);
+}

--- a/lca/src/lca.cpp
+++ b/lca/src/lca.cpp
@@ -32,11 +32,6 @@ constexpr auto operator&=(State& lhs, State rhs) noexcept -> State&
     return lhs;
 }
 
-constexpr auto has_flag(State value, State flag) noexcept -> bool
-{
-    return (value & flag) == flag;
-}
-
 auto lowest_common_ancestor(TreeNode* root, TreeNode* p, TreeNode* q, State& state) -> TreeNode*
 {
     if (root == p) {

--- a/lca/src/tree_node.cpp
+++ b/lca/src/tree_node.cpp
@@ -1,0 +1,7 @@
+#include "tree_node.hpp"
+
+TreeNode::TreeNode() : val(0), left(nullptr), right(nullptr) {}
+
+TreeNode::TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+
+TreeNode::TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}

--- a/lca/tests/BUILD.bazel
+++ b/lca/tests/BUILD.bazel
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "tests-lca",
+    hdrs = glob(["include/*.hpp"], allow_empty = True),
+    strip_include_prefix = "include",
+    srcs = [
+        "src/lca_test_fixture.cpp",
+        "src/lca_generic_test.cpp",
+    ],
+    deps = [
+        "//lca:lca",
+        "@googletest//:gtest_main",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/lca/tests/include/lca_test_fixture.hpp
+++ b/lca/tests/include/lca_test_fixture.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+struct TreeNode;
+
+struct LeastCommonAncestorTestFixture : public ::testing::Test
+{
+protected:
+	struct OwnedTree
+	{
+		TreeNode* make(int value);
+		TreeNode* get(int value) const;
+
+		std::vector<std::unique_ptr<TreeNode>> nodes;
+		std::unordered_map<int, TreeNode*> by_value;
+	};
+
+	OwnedTree build_leetcode_236_example(TreeNode*& root);
+};

--- a/lca/tests/include/lca_test_fixture.hpp
+++ b/lca/tests/include/lca_test_fixture.hpp
@@ -10,7 +10,7 @@ struct TreeNode;
 
 struct LeastCommonAncestorTestFixture : public ::testing::Test
 {
-protected:
+   protected:
     struct OwnedTree
     {
         TreeNode* make(int value);

--- a/lca/tests/include/lca_test_fixture.hpp
+++ b/lca/tests/include/lca_test_fixture.hpp
@@ -11,14 +11,14 @@ struct TreeNode;
 struct LeastCommonAncestorTestFixture : public ::testing::Test
 {
 protected:
-	struct OwnedTree
-	{
-		TreeNode* make(int value);
-		TreeNode* get(int value) const;
+    struct OwnedTree
+    {
+        TreeNode* make(int value);
+        TreeNode* get(int value) const;
 
-		std::vector<std::unique_ptr<TreeNode>> nodes;
-		std::unordered_map<int, TreeNode*> by_value;
-	};
+        std::vector<std::unique_ptr<TreeNode>> nodes;
+        std::unordered_map<int, TreeNode*> by_value;
+    };
 
-	OwnedTree build_leetcode_236_example(TreeNode*& root);
+    OwnedTree build_leetcode_236_example(TreeNode*& root);
 };

--- a/lca/tests/src/lca_generic_test.cpp
+++ b/lca/tests/src/lca_generic_test.cpp
@@ -1,0 +1,84 @@
+#include "lca_test_fixture.hpp"
+
+#include "lca.hpp"
+#include "tree_node.hpp"
+
+TEST_F(LeastCommonAncestorTestFixture, AllNullInputs_ReturnsNullptr)
+{
+    EXPECT_EQ(lowest_common_ancestor(nullptr, nullptr, nullptr), nullptr);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, LeetCodeExample_P5_Q1_LCAIs3)
+{
+    TreeNode* root = nullptr;
+    OwnedTree t = build_leetcode_236_example(root);
+
+    TreeNode* p = t.get(5);
+    TreeNode* q = t.get(1);
+    ASSERT_NE(p, nullptr);
+    ASSERT_NE(q, nullptr);
+
+    EXPECT_EQ(lowest_common_ancestor(root, p, q), root);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, LeetCodeExample_P5_Q4_LCAIs5)
+{
+    TreeNode* root = nullptr;
+    OwnedTree t = build_leetcode_236_example(root);
+
+    TreeNode* p = t.get(5);
+    TreeNode* q = t.get(4);
+    ASSERT_NE(p, nullptr);
+    ASSERT_NE(q, nullptr);
+
+    EXPECT_EQ(lowest_common_ancestor(root, p, q), p);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, SingleNode_PEqualsQEqualsRoot)
+{
+    OwnedTree t;
+    TreeNode* root = t.make(42);
+    EXPECT_EQ(lowest_common_ancestor(root, root, root), root);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, AncestorCase_ReturnsAncestor)
+{
+    // 1
+    // |
+    // 2
+    // |
+    // 3
+    OwnedTree t;
+    TreeNode* root = t.make(1);
+    root->left = t.make(2);
+    root->left->left = t.make(3);
+
+    TreeNode* p = t.get(2);
+    TreeNode* q = t.get(3);
+    ASSERT_NE(p, nullptr);
+    ASSERT_NE(q, nullptr);
+
+    EXPECT_EQ(lowest_common_ancestor(root, p, q), p);
+    EXPECT_EQ(lowest_common_ancestor(root, q, p), p);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, NullInputs_ReturnsNullptr)
+{
+    OwnedTree t;
+    TreeNode* root = t.make(1);
+    TreeNode* p = root;
+
+    EXPECT_EQ(lowest_common_ancestor(nullptr, p, p), nullptr);
+    EXPECT_EQ(lowest_common_ancestor(root, nullptr, p), nullptr);
+    EXPECT_EQ(lowest_common_ancestor(root, p, nullptr), nullptr);
+}
+
+TEST_F(LeastCommonAncestorTestFixture, NodeNotInTree_ReturnsNullptr)
+{
+    OwnedTree t;
+    TreeNode* root = t.make(1);
+    root->left = t.make(2);
+
+    TreeNode orphan(99);
+    EXPECT_EQ(lowest_common_ancestor(root, root->left, &orphan), nullptr);
+}

--- a/lca/tests/src/lca_test_fixture.cpp
+++ b/lca/tests/src/lca_test_fixture.cpp
@@ -1,5 +1,5 @@
-#include "tree_node.hpp"
 #include "lca_test_fixture.hpp"
+#include "tree_node.hpp"
 
 TreeNode* LeastCommonAncestorTestFixture::OwnedTree::make(int value)
 {

--- a/lca/tests/src/lca_test_fixture.cpp
+++ b/lca/tests/src/lca_test_fixture.cpp
@@ -1,0 +1,35 @@
+#include "tree_node.hpp"
+#include "lca_test_fixture.hpp"
+
+TreeNode* LeastCommonAncestorTestFixture::OwnedTree::make(int value)
+{
+    nodes.emplace_back(std::make_unique<TreeNode>(value));
+    TreeNode* ptr = nodes.back().get();
+    by_value[value] = ptr;
+    return ptr;
+}
+
+TreeNode* LeastCommonAncestorTestFixture::OwnedTree::get(int value) const
+{
+    auto it = by_value.find(value);
+    return it == by_value.end() ? nullptr : it->second;
+}
+
+LeastCommonAncestorTestFixture::OwnedTree LeastCommonAncestorTestFixture::build_leetcode_236_example(TreeNode*& root)
+{
+    // Tree: [3,5,1,6,2,0,8,null,null,7,4]
+    OwnedTree t;
+    root = t.make(3);
+    root->left = t.make(5);
+    root->right = t.make(1);
+
+    root->left->left = t.make(6);
+    root->left->right = t.make(2);
+    root->right->left = t.make(0);
+    root->right->right = t.make(8);
+
+    root->left->right->left = t.make(7);
+    root->left->right->right = t.make(4);
+
+    return t;
+}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -16,6 +16,8 @@ cc_test(
         "@ng-log//:ng-log",
         "//level-order:level_order",
         "//level-order/tests:tests-level_order",
+        "//lca:lca",
+        "//lca/tests:tests-lca",
         "//friendly-ll:friendly-ll",
         "//friendly-ll/tests:tests-friendly-ll",
         "//ranges:ranges",


### PR DESCRIPTION
This PR includes two small, logical commits:

- Remove an unused helper in the LCA implementation.
- Fix indentation and include ordering in the LCA test fixture.

CI: `bazel test //...`