### PR TITLE
Add Remove K Digits (monotonic stack) solution + tests

### DIFF
--- a/remove-k-digits/BUILD.bazel
+++ b/remove-k-digits/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "remove-k-digits",
+    srcs = [
+        "src/remove_k_digits.cpp",
+    ],
+    hdrs = glob(["include/*.hpp"], allow_empty = True),
+    includes = [
+        "include",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ng-log//:ng-log",
+    ],
+)

--- a/remove-k-digits/README.md
+++ b/remove-k-digits/README.md
@@ -1,0 +1,7 @@
+# Remove K Digits (LeetCode 402, Medium)
+
+LeetCode: <https://leetcode.com/problems/remove-k-digits/>
+
+Scaffold only: Bazel package + C++ header/source + gtest skeleton.
+
+**Topics**: Greedy, Monotonic Stack

--- a/remove-k-digits/include/remove_k_digits.hpp
+++ b/remove-k-digits/include/remove_k_digits.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// TODO: Implement LeetCode 402 (Remove K Digits).
+
+#include <string>
+
+class RemoveKDigits
+{
+   public:
+    std::string removeKdigits(const std::string &num, int k);
+};

--- a/remove-k-digits/src/remove_k_digits.cpp
+++ b/remove-k-digits/src/remove_k_digits.cpp
@@ -1,0 +1,52 @@
+#include "remove_k_digits.hpp"
+
+#include <ng-log/logging.h>
+
+#include <cstddef>
+#include <stdexcept>
+
+std::string RemoveKDigits::removeKdigits(const std::string& num, int k)
+{
+    LOG(INFO) << "RemoveKDigits::removeKdigits num.size=" << num.size() << " k=" << k;
+
+    if (k < 0)
+    {
+        throw std::invalid_argument("k must be non-negative");
+    }
+    if (num.empty() || static_cast<size_t>(k) >= num.size())
+    {
+        return "0";
+    }
+    if (k == 0)
+    {
+        // Normalize any leading zeros just in case.
+        const size_t first_non_zero = num.find_first_not_of('0');
+        return (first_non_zero == std::string::npos) ? "0" : num.substr(first_non_zero);
+    }
+
+    std::string st;
+    st.reserve(num.size());
+
+    for (const char c : num)
+    {
+        while (k > 0 && !st.empty() && st.back() > c)
+        {
+            st.pop_back();
+            --k;
+        }
+        st.push_back(c);
+    }
+
+    while (k > 0 && !st.empty())
+    {
+        st.pop_back();
+        --k;
+    }
+
+    const size_t first_non_zero = st.find_first_not_of('0');
+    if (first_non_zero == std::string::npos)
+    {
+        return "0";
+    }
+    return st.substr(first_non_zero);
+}

--- a/remove-k-digits/tests/BUILD.bazel
+++ b/remove-k-digits/tests/BUILD.bazel
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files(["COPYING"])
+
+cc_test(
+    name = "tests-remove-k-digits",
+    srcs = [
+        "src/remove_k_digits_generic_test.cpp",
+    ],
+    deps = [
+        "//remove-k-digits:remove-k-digits",
+        "@googletest//:gtest_main",
+        "@ng-log//:ng-log",
+    ],
+)

--- a/remove-k-digits/tests/src/remove_k_digits_generic_test.cpp
+++ b/remove-k-digits/tests/src/remove_k_digits_generic_test.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include "remove_k_digits.hpp"
+
+TEST(RemoveKDigitsGenericTest, Examples)
+{
+    RemoveKDigits solver;
+    EXPECT_EQ(solver.removeKdigits("1432219", 3), "1219");
+    EXPECT_EQ(solver.removeKdigits("10200", 1), "200");
+    EXPECT_EQ(solver.removeKdigits("10", 2), "0");
+}
+
+TEST(RemoveKDigitsGenericTest, EdgeCases)
+{
+    RemoveKDigits solver;
+
+    EXPECT_EQ(solver.removeKdigits("9", 1), "0");
+    EXPECT_EQ(solver.removeKdigits("112", 1), "11");
+    EXPECT_EQ(solver.removeKdigits("10001", 1), "1");
+    EXPECT_EQ(solver.removeKdigits("0000", 0), "0");
+    EXPECT_EQ(solver.removeKdigits("00123", 0), "123");
+    EXPECT_EQ(solver.removeKdigits("00123", 2), "1");
+}


### PR DESCRIPTION
Adds a new Bazel module for LeetCode 402 (Remove K Digits):

- Implementation: greedy monotonic stack in RemoveKDigits::removeKdigits
- Tests: examples + edge cases

Local verification:
- bazel test //remove-k-digits/tests:tests-remove-k-digits
- ./tools/ci.sh