### PR TITLE
Remove TODO comments from headers

### DIFF
--- a/k-closest-points-origin/include/k_closest_points_origin.hpp
+++ b/k-closest-points-origin/include/k_closest_points_origin.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-// TODO: Implement LeetCode 973 (K Closest Points to Origin).
-
 #include <vector>
 
 class KClosestPointsOrigin

--- a/remove-k-digits/include/remove_k_digits.hpp
+++ b/remove-k-digits/include/remove_k_digits.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-// TODO: Implement LeetCode 402 (Remove K Digits).
-
 #include <string>
 
 class RemoveKDigits


### PR DESCRIPTION
Removes stale TODO comment blocks from a couple of header files.

Changes:
- k-closest-points-origin/include/k_closest_points_origin.hpp
- remove-k-digits/include/remove_k_digits.hpp

No functional changes.