### PR TITLE
chore(k-closest): remove unused include

### DIFF
--- a/k-closest-points-origin/tests/src/k_closest_points_origin_generic_test.cpp
+++ b/k-closest-points-origin/tests/src/k_closest_points_origin_generic_test.cpp
@@ -3,7 +3,6 @@
 #include "k_closest_points_origin.hpp"
 
 #include <cstddef>
-#include <cstdint>
 #include <map>
 #include <random>
 #include <utility>


### PR DESCRIPTION
Removes an unused standard library include from the k-closest test to keep headers clean and avoid include-what-you-use warnings.