### PR TITLE
subarray-sum-k: scaffold, tests, and prefix-sum solution

### DIFF
--- a/subarray-sum-k/BUILD.bazel
+++ b/subarray-sum-k/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "subarray-sum-k",
+    srcs = [
+        "src/subarray_sum_k.cpp",
+    ],
+    hdrs = glob(["include/*.hpp"], allow_empty = True),
+    includes = [
+        "include",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ng-log//:ng-log",
+    ],
+)

--- a/subarray-sum-k/README.md
+++ b/subarray-sum-k/README.md
@@ -2,6 +2,9 @@
 
 LeetCode: <https://leetcode.com/problems/subarray-sum-equals-k/>
 
-Scaffold only: Bazel package + C++ header/source + gtest skeleton.
-
 **Topics**: Prefix Sum, Hash Map
+
+Prefix-sum + hash-map solution.
+
+- Time: $O(n)$
+- Space: $O(n)$

--- a/subarray-sum-k/README.md
+++ b/subarray-sum-k/README.md
@@ -1,0 +1,7 @@
+# Subarray Sum Equals K (LeetCode 560, Medium)
+
+LeetCode: <https://leetcode.com/problems/subarray-sum-equals-k/>
+
+Scaffold only: Bazel package + C++ header/source + gtest skeleton.
+
+**Topics**: Prefix Sum, Hash Map

--- a/subarray-sum-k/include/subarray_sum_k.hpp
+++ b/subarray-sum-k/include/subarray_sum_k.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <vector>
+
+class SubarraySumK
+{
+   public:
+    int subarraySum(const std::vector<int> &nums, int k);
+};

--- a/subarray-sum-k/src/subarray_sum_k.cpp
+++ b/subarray-sum-k/src/subarray_sum_k.cpp
@@ -1,0 +1,11 @@
+#include "subarray_sum_k.hpp"
+
+#include <ng-log/logging.h>
+
+int SubarraySumK::subarraySum(const std::vector<int>& nums, int k)
+{
+    (void)nums;
+    (void)k;
+    LOG(INFO) << "SubarraySumK::subarraySum called (scaffold)";
+    return 0;
+}

--- a/subarray-sum-k/src/subarray_sum_k.cpp
+++ b/subarray-sum-k/src/subarray_sum_k.cpp
@@ -1,25 +1,21 @@
 #include "subarray_sum_k.hpp"
 
 #include <ng-log/logging.h>
-
-#include <cstddef>
+#include <unordered_map>
 
 int SubarraySumK::subarraySum(const std::vector<int>& nums, int k)
 {
-    LOG(INFO) << "SubarraySumK::subarraySum called (naive)";
+    LOG(INFO) << "SubarraySumK::subarraySum called (prefix-sum)";
+    std::unordered_map<long long, int> count;
+    count[0] = 1;
 
-    long long count = 0;
-    for (size_t i = 0; i < nums.size(); ++i)
+    long long sum = 0;
+    int ans = 0;
+    for (int x : nums)
     {
-        long long sum = 0;
-        for (size_t j = i; j < nums.size(); ++j)
-        {
-            sum += nums[j];
-            if (sum == static_cast<long long>(k))
-            {
-                ++count;
-            }
-        }
+        sum += x;
+        ans += count[sum - k];
+        ++count[sum];
     }
-    return static_cast<int>(count);
+    return ans;
 }

--- a/subarray-sum-k/src/subarray_sum_k.cpp
+++ b/subarray-sum-k/src/subarray_sum_k.cpp
@@ -2,10 +2,24 @@
 
 #include <ng-log/logging.h>
 
+#include <cstddef>
+
 int SubarraySumK::subarraySum(const std::vector<int>& nums, int k)
 {
-    (void)nums;
-    (void)k;
-    LOG(INFO) << "SubarraySumK::subarraySum called (scaffold)";
-    return 0;
+    LOG(INFO) << "SubarraySumK::subarraySum called (naive)";
+
+    long long count = 0;
+    for (size_t i = 0; i < nums.size(); ++i)
+    {
+        long long sum = 0;
+        for (size_t j = i; j < nums.size(); ++j)
+        {
+            sum += nums[j];
+            if (sum == static_cast<long long>(k))
+            {
+                ++count;
+            }
+        }
+    }
+    return static_cast<int>(count);
 }

--- a/subarray-sum-k/tests/BUILD.bazel
+++ b/subarray-sum-k/tests/BUILD.bazel
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files(["COPYING"])
+
+cc_test(
+    name = "tests-subarray-sum-k",
+    srcs = [
+        "src/subarray_sum_k_generic_test.cpp",
+    ],
+    deps = [
+        "//subarray-sum-k:subarray-sum-k",
+        "@googletest//:gtest_main",
+        "@ng-log//:ng-log",
+    ],
+)

--- a/subarray-sum-k/tests/src/subarray_sum_k_generic_test.cpp
+++ b/subarray-sum-k/tests/src/subarray_sum_k_generic_test.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include "subarray_sum_k.hpp"
+
+#include <cstddef>
+#include <random>
+#include <vector>
+
+namespace
+{
+
+int subarraySumOracle(const std::vector<int>& nums, int k)
+{
+    long long count = 0;
+    for (size_t i = 0; i < nums.size(); ++i)
+    {
+        long long sum = 0;
+        for (size_t j = i; j < nums.size(); ++j)
+        {
+            sum += nums[j];
+            if (sum == static_cast<long long>(k))
+            {
+                ++count;
+            }
+        }
+    }
+    return static_cast<int>(count);
+}
+
+}  // namespace
+
+TEST(SubarraySumKGenericTest, Empty)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({}, 0), 0);
+    EXPECT_EQ(solver.subarraySum({}, 5), 0);
+}
+
+TEST(SubarraySumKGenericTest, SingleElement)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({5}, 5), 1);
+    EXPECT_EQ(solver.subarraySum({5}, 0), 0);
+    EXPECT_EQ(solver.subarraySum({-7}, -7), 1);
+}
+
+TEST(SubarraySumKGenericTest, LeetCodeExample)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({1, 1, 1}, 2), 2);
+}
+
+TEST(SubarraySumKGenericTest, NonRotatedSimple)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({1, 2, 3}, 3), 2);
+}
+
+TEST(SubarraySumKGenericTest, HandlesNegatives)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({1, -1, 0}, 0), 3);
+    EXPECT_EQ(solver.subarraySum({-1, -1, 1}, -1), 3);
+}
+
+TEST(SubarraySumKGenericTest, AllZeros)
+{
+    SubarraySumK solver;
+    EXPECT_EQ(solver.subarraySum({0, 0, 0}, 0), 6);
+    EXPECT_EQ(solver.subarraySum({0, 0, 0, 0}, 0), 10);
+}
+
+TEST(SubarraySumKGenericTest, RandomizedAgainstOracle)
+{
+    SubarraySumK solver;
+
+    std::mt19937 rng(0xC0FFEE);
+    std::uniform_int_distribution<int> nDist(0, 50);
+    std::uniform_int_distribution<int> valDist(-5, 5);
+    std::uniform_int_distribution<int> kDist(-10, 10);
+
+    for (int iter = 0; iter < 500; ++iter)
+    {
+        const int n = nDist(rng);
+        std::vector<int> nums;
+        nums.reserve(static_cast<size_t>(n));
+        for (int i = 0; i < n; ++i)
+        {
+            nums.push_back(valDist(rng));
+        }
+
+        const int k = kDist(rng);
+        EXPECT_EQ(solver.subarraySum(nums, k), subarraySumOracle(nums, k))
+            << "iter=" << iter << " n=" << n << " k=" << k;
+    }
+}


### PR DESCRIPTION
Adds the new subarray-sum-k module with incremental commits:

1) scaffold (Bazel target + header/source)
2) comprehensive gtest suite + naive baseline for correctness
3) optimized prefix-sum + hashmap implementation

Tests: bazel test -c dbg //subarray-sum-k/tests:tests-subarray-sum-k